### PR TITLE
updates for profile pics and app-feed aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ schemas.addContact(feed, target, {
     size: number, // in bytes
     width: number, // in pixels (optional)
     height: number // in pixels (optional)
-  }
+  },
+  master: { feed: hash } // makes the contact a subfeed of the linked-to feed
 }, cb)
 schemas.addPub(address, cb)
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ schemas.validate(content)
 // individual validator functions (by message type)
 schemas.validators.post(content)
 schemas.validators.advert(content)
-schemas.validators.name(content)
 schemas.validators.contact(content)
 schemas.validators.pub(content)
 
@@ -20,8 +19,18 @@ schemas.validators.pub(content)
 // - `feed` should be the feed interface, eg an ssb feed or sbot rpc api
 schemas.addPost(feed, text, [{ repliesTo: link, refers: links, mentions: links, attachments: links }], cb)
 schemas.addAdvert(feed, text, cb)
-schemas.addName(feed, name, cb)
-schemas.addContact(feed, target, { following: bool, name: string, trust: -1|0|1 }, cb)
+schemas.addContact(feed, target, {
+  following: bool,
+  name: string,
+  trust: -1|0|1,
+  profilePic: {
+    ext: hash,
+    type: string, // should be an image mimetype, eg 'image/png'
+    size: number, // in bytes
+    width: number, // in pixels (optional)
+    height: number // in pixels (optional)
+  }
+}, cb)
 schemas.addPub(address, cb)
 
 // errors

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ schemas.addContact(feed, target, {
 }, cb)
 schemas.addPub(address, cb)
 
+// get functions
+schemas.getContact(ssb, { by: feed_id, for: feed_id }, cbb)
+
 // errors
 schemas.errors.UnknownType
 schemas.errors.MalformedMessage

--- a/index.js
+++ b/index.js
@@ -46,13 +46,19 @@ exports.validators = {
       return new errors.MalformedMessage('contact link is required')
     if (!allLinksValid(links, 'feed'))
       return new errors.BadLinkAttr('contact', 'feed', 'contact link must have a valid feed reference')
-    if (!allLinksValid(mlib.asLinks(content.profilePic), 'ext'))
+
+    if ('profilePic' in content && !allLinksValid(mlib.asLinks(content.profilePic), 'ext'))
       return new errors.BadLinkAttr('profilePic', 'ext', 'profilePic link must have a valid ext reference')
+
+    if ('master' in content && !allLinksValid(mlib.asLinks(content.master), 'ext'))
+      return new errors.BadLinkAttr('master', 'feed', 'master link must have a valid feed reference')
 
     if ('name' in content && (typeof content.name != 'string' || !content.name.trim()))
       return new errors.BadAttr('text', 'Contact msgs must have a `.name` string that is not blank')
+
     if ('following' in content && content.following !== true && content.following !== false)
       return new errors.BadAttr('following', 'Contact msgs must have a `.following` of true or false')
+    
     if ('trust' in content && content.trust !== -1 && content.trust !== 0 && content.trust !== 1)
       return new errors.BadAttr('trust', 'Contact msgs must have a `.trust` of -1, 0, or 1')
   },

--- a/index.js
+++ b/index.js
@@ -39,11 +39,6 @@ exports.validators = {
       return new errors.BadAttr('text', 'Can not create an empty advert')
   },
 
-  name: function (content) {
-    if (typeof content.name != 'string' || !content.name.trim())
-      return new errors.BadAttr('text', 'Can not use an empty name')
-  },
-
   contact: function (content) {
     var links = mlib.asLinks(content.contact)
     if (links.length === 0)
@@ -100,9 +95,6 @@ var schemas = exports.schemas = {
   },
   advert: function (text) {
     return { type: 'advert', text: text }
-  },
-  name: function (name) {
-    return { type: 'name', name: name }
   },
   contact: function (contact, opts) {
     var content = { type: 'contact', contact: { feed: contact } }

--- a/index.js
+++ b/index.js
@@ -76,7 +76,8 @@ var validateAndAdd =
 exports.validateAndAdd = function (feed, content, cb) {
   var err = validate(content)
   if (err) return cb(err)
-  feed.publish(content, cb)
+  var adder = feed.publish || feed.add
+  adder.call(feed, content, cb)
 }
 
 var schemas = exports.schemas = {

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ exports.validators = {
     if ('profilePic' in content && !allLinksValid(mlib.asLinks(content.profilePic), 'ext'))
       return new errors.BadLinkAttr('profilePic', 'ext', 'profilePic link must have a valid ext reference')
 
-    if ('master' in content && !allLinksValid(mlib.asLinks(content.master), 'ext'))
+    if ('master' in content && !allLinksValid(mlib.asLinks(content.master), 'feed'))
       return new errors.BadLinkAttr('master', 'feed', 'master link must have a valid feed reference')
 
     if ('name' in content && (typeof content.name != 'string' || !content.name.trim()))
@@ -58,7 +58,7 @@ exports.validators = {
 
     if ('following' in content && content.following !== true && content.following !== false)
       return new errors.BadAttr('following', 'Contact msgs must have a `.following` of true or false')
-    
+
     if ('trust' in content && content.trust !== -1 && content.trust !== 0 && content.trust !== 1)
       return new errors.BadAttr('trust', 'Contact msgs must have a `.trust` of -1, 0, or 1')
   },

--- a/index.js
+++ b/index.js
@@ -100,15 +100,8 @@ var schemas = exports.schemas = {
   },
   contact: function (contact, opts) {
     var content = { type: 'contact', contact: { feed: contact } }
-    if (opts) {
-      if ('name' in opts)
-        content.name = opts.name
-      if ('trust' in opts)
-        content.trust = opts.trust
-      if ('following' in opts)
-        content.following = opts.following
-      if ('profilePic' in opts)
-        content.profilePic = opts.profilePic
+    for (var k in opts) {
+      content[k] = opts[k]
     }
     return content
   },

--- a/index.js
+++ b/index.js
@@ -50,6 +50,8 @@ exports.validators = {
       return new errors.MalformedMessage('contact link is required')
     if (!allLinksValid(links, 'feed'))
       return new errors.BadLinkAttr('contact', 'feed', 'contact link must have a valid feed reference')
+    if (!allLinksValid(mlib.asLinks(content.profilePic), 'ext'))
+      return new errors.BadLinkAttr('profilePic', 'ext', 'profilePic link must have a valid ext reference')
 
     if ('name' in content && (typeof content.name != 'string' || !content.name.trim()))
       return new errors.BadAttr('text', 'Contact msgs must have a `.name` string that is not blank')
@@ -78,7 +80,7 @@ var validateAndAdd =
 exports.validateAndAdd = function (feed, content, cb) {
   var err = validate(content)
   if (err) return cb(err)
-  feed.add(content, cb)
+  feed.publish(content, cb)
 }
 
 var schemas = exports.schemas = {
@@ -111,6 +113,8 @@ var schemas = exports.schemas = {
         content.trust = opts.trust
       if ('following' in opts)
         content.following = opts.following
+      if ('profilePic' in opts)
+        content.profilePic = opts.profilePic
     }
     return content
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ssb-msg-schemas",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "validation and publishing methods for common ssb message types",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "url": "git://github.com/ssbc/ssb-msg-schemas.git"
   },
   "dependencies": {
+    "pull-stream": "~2.26.0",
     "ssb-msgs": "~3.0.0"
   },
   "author": "Paul Frazee <pfrazee@gmail.com>",


### PR DESCRIPTION
per https://github.com/ssbc/phoenix/issues/340#issuecomment-78395335
- completely removes `type: name` messages in favor of self-linking `type: contact` messages
- adds validation for `.profilePic` and `.master` links in `type: contact`
- adds `.getContact` to compute the full current state of a contact
