### PR TITLE
Add `channel` to posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ schemas.pub(id, host, port)
 { type: 'post', text: String, topic: String, root: MsgLink, branch: MsgLink, recps: FeedLinks, mentions: Links }
 ```
 
- - `topic` is used to filter posts into groups, similar to subreddits or chat channels. 
+ - `topic` is optionally used to filter posts into groups, similar to subreddits or chat channels. 
+   - If not specified, the post is in the main feed.
  - `root` and `branch` are for replies.
    - `root` should point to the topmost message in the thread.
    - `branch` should point to the message in the thread which is being replied to.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Functions to create common SSB messages.
 
 ```js
-{ type: 'post', text: String, topic: String, root: MsgLink, branch: MsgLink, recps: FeedLinks, mentions: Links }
+{ type: 'post', text: String, channel: String, root: MsgLink, branch: MsgLink, recps: FeedLinks, mentions: Links }
 { type: 'about', about: Link, name: String, image: BlobLink }
 { type: 'contact', contact: FeedLink, following: Bool, blocking: Bool }
 { type: 'vote', vote: { link: Ref, value: -1|0|1, reason: String } }
@@ -14,8 +14,8 @@ Functions to create common SSB messages.
 ```js
 var schemas = require('ssb-msg-schemas')
 
-schemas.post(text, root (optional), branch (optional), mentions (optional), recps (optional), topic (optional))
-// => { type: 'post', text: text, topic: topic, root: root, branch: branch, mentions: mentions, recps: recps }
+schemas.post(text, root (optional), branch (optional), mentions (optional), recps (optional), channel (optional))
+// => { type: 'post', text: text, channel: channel, root: root, branch: branch, mentions: mentions, recps: recps }
 schemas.name(id, name)
 // => { type: 'about', about: id, name: name }
 schemas.image(id, imgLink)
@@ -41,11 +41,10 @@ schemas.pub(id, host, port)
 ### type: post
 
 ```js
-{ type: 'post', text: String, topic: String, root: MsgLink, branch: MsgLink, recps: FeedLinks, mentions: Links }
+{ type: 'post', text: String, channel: String, root: MsgLink, branch: MsgLink, recps: FeedLinks, mentions: Links }
 ```
 
- - `topic` is optionally used to filter posts into groups, similar to subreddits or chat channels. 
-   - If not specified, the post is in the main feed.
+ - `channel` is optionally used to filter posts into groups, similar to subreddits or chat channels.
  - `root` and `branch` are for replies.
    - `root` should point to the topmost message in the thread.
    - `branch` should point to the message in the thread which is being replied to.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Functions to create common SSB messages.
 
 ```js
-{ type: 'post', text: String, root: MsgLink, branch: MsgLink, recps: FeedLinks, mentions: Links }
+{ type: 'post', text: String, topic: String, root: MsgLink, branch: MsgLink, recps: FeedLinks, mentions: Links }
 { type: 'about', about: Link, name: String, image: BlobLink }
 { type: 'contact', contact: FeedLink, following: Bool, blocking: Bool }
 { type: 'vote', vote: { link: Ref, value: -1|0|1, reason: String } }
@@ -14,8 +14,8 @@ Functions to create common SSB messages.
 ```js
 var schemas = require('ssb-msg-schemas')
 
-schemas.post(text, root (optional), branch (optional), mentions (optional), recps (optional))
-// => { type: 'post', text: text, root: root, branch: branch, mentions: mentions, recps: recps }
+schemas.post(text, root (optional), branch (optional), mentions (optional), recps (optional), topic (optional))
+// => { type: 'post', text: text, topic: topic, root: root, branch: branch, mentions: mentions, recps: recps }
 schemas.name(id, name)
 // => { type: 'about', about: id, name: name }
 schemas.image(id, imgLink)
@@ -41,9 +41,10 @@ schemas.pub(id, host, port)
 ### type: post
 
 ```js
-{ type: 'post', text: String, root: MsgLink, branch: MsgLink, recps: FeedLinks, mentions: Links }
+{ type: 'post', text: String, topic: String, root: MsgLink, branch: MsgLink, recps: FeedLinks, mentions: Links }
 ```
 
+ - `topic` is used to filter posts into groups, similar to subreddits or chat channels. 
  - `root` and `branch` are for replies.
    - `root` should point to the topmost message in the thread.
    - `branch` should point to the message in the thread which is being replied to.

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ function links (l) {
   return l.map(link)
 }
 
-exports.post = function (text, root, branch, mentions, recps, topic) {
+exports.post = function (text, root, branch, mentions, recps, channel) {
   var content = { type: 'post', text: text }
   if (root) {
     root = link(root)
@@ -47,10 +47,10 @@ exports.post = function (text, root, branch, mentions, recps, topic) {
       throw new Error('recps are not valid links')
     content.recps = recps
   }
-  if (topic) {
-    if (typeof topic !== 'string')
-      throw new Error('topic must be a string')
-    content.topic = topic
+  if (channel) {
+    if (typeof channel !== 'string')
+      throw new Error('channel must be a string')
+    content.channel = channel
   }
 
   return content

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ function links (l) {
   return l.map(link)
 }
 
-exports.post = function (text, root, branch, mentions, recps) {
+exports.post = function (text, root, branch, mentions, recps, topic) {
   var content = { type: 'post', text: text }
   if (root) {
     root = link(root)
@@ -47,6 +47,12 @@ exports.post = function (text, root, branch, mentions, recps) {
       throw new Error('recps are not valid links')
     content.recps = recps
   }
+  if (topic) {
+    if (typeof topic !== 'string')
+      throw new Error('topic must be a string')
+    content.topic = topic
+  }
+
   return content
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -25,7 +25,7 @@ tape('schemas', function (t) {
   )
   t.deepEqual(
     schemas.post('text', null, null, null, null, 'stuff'),
-    { type: 'post', text: 'text', topic: 'stuff' }
+    { type: 'post', text: 'text', channel: 'stuff' }
   )
   t.deepEqual(
     schemas.name(feedid, 'name'),

--- a/test/index.js
+++ b/test/index.js
@@ -24,6 +24,10 @@ tape('schemas', function (t) {
     { type: 'post', text: 'text', root: msgid, branch: msgid2, mentions: [feedid, msgid, blobid], recps: [feedid] }
   )
   t.deepEqual(
+    schemas.post('text', null, null, null, null, 'stuff'),
+    { type: 'post', text: 'text', topic: 'stuff' }
+  )
+  t.deepEqual(
     schemas.name(feedid, 'name'),
     { type: 'about', about: feedid, name: 'name' }
   )


### PR DESCRIPTION
Adds `channel` string-field to posts. Supercedes https://github.com/ssbc/ssb-msg-schemas/pull/12
