### PR TITLE
Tracking PR: add postEdit function to schemas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Functions to create common SSB messages.
 
 ```js
 { type: 'post', text: String, channel: String, root: MsgLink, branch: MsgLink, recps: FeedLinks, mentions: Links }
-{ type: 'post-edit', text: String, root: MsgLink, revision: MsgLink, mentions: Links }
+{ type: 'post-edit', text: String, root: MsgLink, revisionRoot: MsgLink, revisionBranch: MsgLink, mentions: Links }
 { type: 'about', about: Link, name: String, image: BlobLink }
 { type: 'contact', contact: FeedLink, following: Bool, blocking: Bool }
 { type: 'vote', vote: { link: Ref, value: -1|0|1, reason: String } }
@@ -17,8 +17,8 @@ var schemas = require('ssb-msg-schemas')
 
 schemas.post(text, root (optional), branch (optional), mentions (optional), recps (optional), channel (optional))
 // => { type: 'post', text: text, channel: channel, root: root, branch: branch, mentions: mentions, recps: recps }
-schemas.postEdit(text, root, mentions (optional), revision)
-// => { type: 'post-edit', text: text, root: root, revision: revision, mentions: mentions}
+schemas.postEdit(text, root, revisionRoot, revisionBranch, mentions (optional))
+// => { type: 'post-edit', text: text, root: root, revisionRoot: revisionRoot, revisionBranch: revisionBranch, mentions: mentions }
 schemas.name(id, name)
 // => { type: 'about', about: id, name: name }
 schemas.image(id, imgLink)
@@ -63,15 +63,20 @@ schemas.pub(id, host, port)
 ### type: postEdit
 
 ```js
-{ type: 'post-edit', text: text, root: root, revision: revision, mentions: mentions}
+{ type: 'post-edit', text: String, root: MsgLink, revisionRoot: MsgLink, revisionBranch: MsgLink, mentions: Links }
 ```
 
 - `text` is used for posting the revised text that should take the place of some
   previous text.
-- `root` should point to the topmost message in the thread.
-- `revision` points to a message that should be revised with `text`.
+- `root` should point to the topmost message in the thread (i.e., the original
+  thread root).
+- `revisionRoot` points the original 'unrevised message', i.e., the root of the
+  revision thread.
+- `revisionBranch` should point to the previous revision in the revision
+  thread. If this is the first edit to a message, `revisionRoot` and
+  `revisionBranch` will be the same.
 - `mentions` is used as in `post`, replacing the previous `mentions` of the
-  message in `revision`.
+  message in `revisionBranch`.
 
 
 ### type: about

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Functions to create common SSB messages.
 
 ```js
 { type: 'post', text: String, channel: String, root: MsgLink, branch: MsgLink, recps: FeedLinks, mentions: Links }
-{ type: 'post-edit', text: String, revision: MsgLink, mentions: Links }
+{ type: 'post-edit', text: String, root: MsgLink, revision: MsgLink, mentions: Links }
 { type: 'about', about: Link, name: String, image: BlobLink }
 { type: 'contact', contact: FeedLink, following: Bool, blocking: Bool }
 { type: 'vote', vote: { link: Ref, value: -1|0|1, reason: String } }
@@ -17,8 +17,8 @@ var schemas = require('ssb-msg-schemas')
 
 schemas.post(text, root (optional), branch (optional), mentions (optional), recps (optional), channel (optional))
 // => { type: 'post', text: text, channel: channel, root: root, branch: branch, mentions: mentions, recps: recps }
-schemas.postEdit(text, mentions (optional), revision)
-// => { type: 'post-edit', text: text, revision: revision, mentions: mentions}
+schemas.postEdit(text, root, mentions (optional), revision)
+// => { type: 'post-edit', text: text, root: root, revision: revision, mentions: mentions}
 schemas.name(id, name)
 // => { type: 'about', about: id, name: name }
 schemas.image(id, imgLink)
@@ -63,11 +63,12 @@ schemas.pub(id, host, port)
 ### type: postEdit
 
 ```js
-{ type: 'post-edit', text: text, revision: revision, mentions: mentions}
+{ type: 'post-edit', text: text, root: root, revision: revision, mentions: mentions}
 ```
 
 - `text` is used for posting the revised text that should take the place of some
   previous text.
+- `root` should point to the topmost message in the thread.
 - `revision` points to a message that should be revised with `text`.
 - `mentions` is used as in `post`, replacing the previous `mentions` of the
   message in `revision`.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Functions to create common SSB messages.
 
 ```js
 { type: 'post', text: String, channel: String, root: MsgLink, branch: MsgLink, recps: FeedLinks, mentions: Links }
+{ type: 'post-edit', text: String, revision: MsgLink, mentions: Links }
 { type: 'about', about: Link, name: String, image: BlobLink }
 { type: 'contact', contact: FeedLink, following: Bool, blocking: Bool }
 { type: 'vote', vote: { link: Ref, value: -1|0|1, reason: String } }
@@ -16,6 +17,8 @@ var schemas = require('ssb-msg-schemas')
 
 schemas.post(text, root (optional), branch (optional), mentions (optional), recps (optional), channel (optional))
 // => { type: 'post', text: text, channel: channel, root: root, branch: branch, mentions: mentions, recps: recps }
+schemas.postEdit(text, mentions (optional), revision)
+// => { type: 'post-edit', text: text, revision: revision, mentions: mentions}
 schemas.name(id, name)
 // => { type: 'about', about: id, name: name }
 schemas.image(id, imgLink)
@@ -56,6 +59,19 @@ schemas.pub(id, host, port)
    - It is used by message-mentions (to reference non-post messages).
  - `recps` is a list of user-links specifying who the message is for.
    - This is typically used for encrypted messages, to specify who the message was encrypted for.
+
+### type: postEdit
+
+```js
+{ type: 'post-edit', text: text, revision: revision, mentions: mentions}
+```
+
+- `text` is used for posting the revised text that should take the place of some
+  previous text.
+- `revision` points to a message that should be revised with `text`.
+- `mentions` is used as in `post`, replacing the previous `mentions` of the
+  message in `revision`.
+
 
 ### type: about
 

--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ exports.post = function (text, root, branch, mentions, recps, channel) {
   return content
 }
 
-exports.postEdit = function(text, root, mentions, revision) {
+exports.postEdit = function(text, root, revisionRoot, revisionBranch, mentions) {
   var content = { type: 'post-edit', text: text }
   if (root) {
     root = link(root)
@@ -64,12 +64,17 @@ exports.postEdit = function(text, root, mentions, revision) {
       throw new Error('root is not a valid link')
     content.root = root
   }
-  if (revision) { // Revisions are like branches, except they form a differently
-                  // templated (and regarded) thread
-    revision = link(revision)
-    if (!revision)
-      throw new Error('revision is not a valid link')
-    content.revision = revision
+  if (revisionRoot) {
+    revisionRoot = link(revisionRoot)
+    if (!revisionRoot)
+      throw new Error('revisionRoot is not a valid link')
+    content.revisionRoot = revisionRoot
+  }
+  if (revisionBranch) {
+    revisionBranch = link(revisionBranch)
+    if (!revisionBranch)
+      throw new Error('revisionBranch is not a valid link')
+    content.revisionBranch = revisionBranch
   }
   if (mentions && (!Array.isArray(mentions) || mentions.length)) {
     mentions = links(mentions)

--- a/index.js
+++ b/index.js
@@ -56,8 +56,14 @@ exports.post = function (text, root, branch, mentions, recps, channel) {
   return content
 }
 
-exports.postEdit = function(text, mentions, revision) {
+exports.postEdit = function(text, root, mentions, revision) {
   var content = { type: 'post-edit', text: text }
+  if (root) {
+    root = link(root)
+    if (!root)
+      throw new Error('root is not a valid link')
+    content.root = root
+  }
   if (revision) { // Revisions are like branches, except they form a differently
                   // templated (and regarded) thread
     revision = link(revision)

--- a/index.js
+++ b/index.js
@@ -56,6 +56,48 @@ exports.post = function (text, root, branch, mentions, recps, channel) {
   return content
 }
 
+exports.postEdit = function(text, root, branch, mentions, recps, channel, revision) {
+  var content = { type: 'post-edit', text: text }
+  if (root) {
+    root = link(root)
+    if (!root)
+      throw new Error('root is not a valid link')
+    content.root = root
+  }
+  if (branch) {
+    branch = link(branch)
+    if (!branch)
+      throw new Error('branch is not a valid link')
+    content.branch = branch
+  }
+  if (revision) { // Revisions are like branches, except they form a differently
+                  // templated (and regarded) thread
+    revision = link(branch)
+    if (!revision)
+      throw new Error('revision is not a valid link')
+    content.revision = revision
+  }
+  if (mentions && (!Array.isArray(mentions) || mentions.length)) {
+    mentions = links(mentions)
+    if (!mentions || !mentions.length)
+      throw new Error('mentions are not valid links')
+    content.mentions = mentions
+  }
+  if (recps && (!Array.isArray(recps) || recps.length)) {
+    recps = links(recps)
+    if (!recps || !recps.length)
+      throw new Error('recps are not valid links')
+    content.recps = recps
+  }
+  if (channel) {
+    if (typeof channel !== 'string')
+      throw new Error('channel must be a string')
+    content.channel = channel
+  }
+
+  return content  
+}
+
 exports.name = function (userId, name) {
   return { type: 'about', about: link(userId), name: name }
 }

--- a/index.js
+++ b/index.js
@@ -56,23 +56,11 @@ exports.post = function (text, root, branch, mentions, recps, channel) {
   return content
 }
 
-exports.postEdit = function(text, root, branch, mentions, recps, channel, revision) {
+exports.postEdit = function(text, mentions, revision) {
   var content = { type: 'post-edit', text: text }
-  if (root) {
-    root = link(root)
-    if (!root)
-      throw new Error('root is not a valid link')
-    content.root = root
-  }
-  if (branch) {
-    branch = link(branch)
-    if (!branch)
-      throw new Error('branch is not a valid link')
-    content.branch = branch
-  }
   if (revision) { // Revisions are like branches, except they form a differently
                   // templated (and regarded) thread
-    revision = link(branch)
+    revision = link(revision)
     if (!revision)
       throw new Error('revision is not a valid link')
     content.revision = revision
@@ -83,18 +71,7 @@ exports.postEdit = function(text, root, branch, mentions, recps, channel, revisi
       throw new Error('mentions are not valid links')
     content.mentions = mentions
   }
-  if (recps && (!Array.isArray(recps) || recps.length)) {
-    recps = links(recps)
-    if (!recps || !recps.length)
-      throw new Error('recps are not valid links')
-    content.recps = recps
-  }
-  if (channel) {
-    if (typeof channel !== 'string')
-      throw new Error('channel must be a string')
-    content.channel = channel
-  }
-
+  
   return content  
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -28,6 +28,14 @@ tape('schemas', function (t) {
     { type: 'post', text: 'text', channel: 'stuff' }
   )
   t.deepEqual(
+    schemas.postEdit('revised text', feedid, msgid),
+    { type: 'post-edit', text: 'revised text', revision: msgid, mentions: [feedid]}
+  )
+  t.deepEqual(
+    schemas.postEdit('revised text', null, msgid2),
+    { type: 'post-edit', text: 'revised text', revision: msgid2}
+  )
+  t.deepEqual(
     schemas.name(feedid, 'name'),
     { type: 'about', about: feedid, name: 'name' }
   )

--- a/test/index.js
+++ b/test/index.js
@@ -28,12 +28,12 @@ tape('schemas', function (t) {
     { type: 'post', text: 'text', channel: 'stuff' }
   )
   t.deepEqual(
-    schemas.postEdit('revised text', msgid, [feedid], msgid),
-    { type: 'post-edit', text: 'revised text', root: msgid, revision: msgid, mentions: [feedid]}
+    schemas.postEdit('revised text', msgid, msgid, msgid, [feedid]),
+    { type: 'post-edit', text: 'revised text', root: msgid, revisionRoot: msgid, revisionBranch: msgid, mentions: [feedid]}
   )
   t.deepEqual(
-    schemas.postEdit('revised text', msgid, null, msgid2),
-    { type: 'post-edit', text: 'revised text', root: msgid, revision: msgid2}
+    schemas.postEdit('revised text', msgid, msgid2, msgid2, null),
+    { type: 'post-edit', text: 'revised text', root: msgid, revisionRoot: msgid2, revisionBranch: msgid2}
   )
   t.deepEqual(
     schemas.name(feedid, 'name'),

--- a/test/index.js
+++ b/test/index.js
@@ -28,12 +28,12 @@ tape('schemas', function (t) {
     { type: 'post', text: 'text', channel: 'stuff' }
   )
   t.deepEqual(
-    schemas.postEdit('revised text', feedid, msgid),
-    { type: 'post-edit', text: 'revised text', revision: msgid, mentions: [feedid]}
+    schemas.postEdit('revised text', msgid, [feedid], msgid),
+    { type: 'post-edit', text: 'revised text', root: msgid, revision: msgid, mentions: [feedid]}
   )
   t.deepEqual(
-    schemas.postEdit('revised text', null, msgid2),
-    { type: 'post-edit', text: 'revised text', revision: msgid2}
+    schemas.postEdit('revised text', msgid, null, msgid2),
+    { type: 'post-edit', text: 'revised text', root: msgid, revision: msgid2}
   )
   t.deepEqual(
     schemas.name(feedid, 'name'),


### PR DESCRIPTION
- includes 'revision' arg

Starting the PR early so that we can have a conversation about it. As @pfraze suggested, adding both `postEdit()` (camelCased in object, lisp-cased in string vals) and `revision`. Leaving everything else the same for now.

Some concerns:
- the first reply might have a root+branch that correspond to an unrevised post--this means that threads have to look for a reply along each of the revisions--or should replies be updated on postEdit to always connect to the latest item in a revision chain?
- replies should also be editable--I think this means that if every post in a thread of length `~n` has `~m` revisions, there are `O(nm)` steps to be carried out when assembling a thread. How to solve without getting too clever?
- I think it's simplest to regard revisions with zero-length as deletes, instead of establishing an entirely new type for them.
- How to handle deletes? If there are threads dangling from them, should there be a placeholder, or should the thread be hidden? (Would like to avoid hiding the thread in this case, since low-level examination can always extract them.)
