### PR TITLE
Add validators

### DIFF
--- a/about.js
+++ b/about.js
@@ -1,4 +1,7 @@
-const { link } = require('./util/link')
+const Validate = require('is-my-json-valid')
+const { feedIdRegex, blobIdRegex } = require('ssb-ref')
+
+const { link, stringifyRegex } = require('./util')
 
 function name (userId, name) {
   return {
@@ -16,10 +19,43 @@ function image (userId, imgLink) {
   }
 }
 
-const schema = {}
-
-function validate () {
+const schema = {
+  $schema: 'https://www.github.com/ssbc/patchcore',
+  type: 'object',
+  required: ['type', 'about'],
+  anyOf: [
+    { required: ['name'] },
+    { required: ['image'] }
+  ],
+  properties: {
+    type: {
+      type: 'string',
+      pattern: '^about$'
+    },
+    about: {
+      type: 'string',
+      pattern: stringifyRegex(feedIdRegex)
+    },
+    name: {
+      type: 'string'
+    },
+    image: {
+      type: 'object',
+      required: ['link', 'size'],
+      properties: {
+        link: {
+          type: 'string',
+          pattern: blobIdRegex
+        },
+        size: {
+          type: 'integer'
+        }
+      }
+    }
+  }
 }
+
+const validate = Validate(schema, { verbose: true })
 
 module.exports = {
   create: {

--- a/about.js
+++ b/about.js
@@ -20,7 +20,7 @@ function image (userId, imgLink) {
 }
 
 const schema = {
-  $schema: 'https://www.github.com/ssbc/patchcore',
+  $schema: 'http://json-schema.org/schema#',
   type: 'object',
   required: ['type', 'about'],
   // TODO : extract for about profile in patchbay

--- a/about.js
+++ b/about.js
@@ -1,7 +1,7 @@
 const Validate = require('is-my-json-valid')
 const { feedIdRegex, blobIdRegex } = require('ssb-ref')
 
-const { link, stringifyRegex } = require('./util')
+const { link } = require('./util')
 
 function name (userId, name) {
   return {
@@ -23,11 +23,12 @@ const schema = {
   $schema: 'https://www.github.com/ssbc/patchcore',
   type: 'object',
   required: ['type', 'about'],
-  anyOf: [
-    { required: ['name'] },
-    { required: ['description'] },
-    { required: ['image'] }
-  ],
+  // TODO : extract for about profile in patchbay
+  // anyOf: [
+  //   { required: ['name'] },
+  //   { required: ['description'] },
+  //   { required: ['image'] }
+  // ],
   properties: {
     type: {
       type: 'string',
@@ -35,22 +36,30 @@ const schema = {
     },
     about: {
       type: 'string',
-      pattern: stringifyRegex(feedIdRegex)
+      pattern: feedIdRegex
     },
     name: { type: 'string' },
     description: { type: 'string' },
     image: {
-      type: 'object',
-      required: ['link', 'size'],
-      properties: {
-        link: {
+      anyOf: [
+        {
           type: 'string',
           pattern: blobIdRegex
         },
-        size: {
-          type: 'integer'
-        }
-      }
+        {
+          type: 'object',
+          required: ['link', 'size'],
+          properties: {
+            link: {
+              type: 'string',
+              pattern: blobIdRegex
+            },
+            size: {
+              type: 'integer'
+            }
+          }
+        } 
+      ]
     }
   }
 }

--- a/about.js
+++ b/about.js
@@ -25,6 +25,7 @@ const schema = {
   required: ['type', 'about'],
   anyOf: [
     { required: ['name'] },
+    { required: ['description'] },
     { required: ['image'] }
   ],
   properties: {
@@ -36,9 +37,8 @@ const schema = {
       type: 'string',
       pattern: stringifyRegex(feedIdRegex)
     },
-    name: {
-      type: 'string'
-    },
+    name: { type: 'string' },
+    description: { type: 'string' },
     image: {
       type: 'object',
       required: ['link', 'size'],

--- a/about.js
+++ b/about.js
@@ -1,0 +1,32 @@
+const { link } = require('./util/link')
+
+function name (userId, name) {
+  return {
+    type: 'about',
+    about: link(userId),
+    name
+  }
+}
+
+function image (userId, imgLink) {
+  return {
+    type: 'about',
+    about: link(userId),
+    image: link(imgLink)
+  }
+}
+
+const schema = {}
+
+function validate () {
+}
+
+module.exports = {
+  create: {
+    name,
+    image
+  },
+  schema,
+  validate
+}
+

--- a/contact.js
+++ b/contact.js
@@ -1,0 +1,34 @@
+const { link } = require('./util/link')
+
+function follow (userId) {
+  return { type: 'contact', contact: link(userId), following: true, blocking: false }
+}
+
+function unfollow (userId) {
+  return { type: 'contact', contact: link(userId), following: false }
+}
+
+function block (userId) {
+  return { type: 'contact', contact: link(userId), following: false, blocking: true }
+}
+
+function unblock (userId) {
+  return { type: 'contact', contact: link(userId), blocking: false }
+}
+
+const schema = {}
+
+function validate () {
+}
+
+module.exports = {
+  create: {
+    follow,
+    unfollow,
+    block,
+    unblock
+  },
+  schema,
+  validate
+}
+

--- a/contact.js
+++ b/contact.js
@@ -1,4 +1,4 @@
-const { link } = require('./util/link')
+const { link } = require('./util')
 
 function follow (userId) {
   return { type: 'contact', contact: link(userId), following: true, blocking: false }

--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ const {
 } = require('./contact')
 
 const {
-  create: post
+  create: post,
+  validate: isPost
 } = require('./post')
 
 
@@ -28,7 +29,7 @@ const {
 module.exports = {
   name, image, aboutSchema, isAbout,
   follow, unfollow, block, unblock,
-  post,
+  post, isPost,
   pub,
   vote
 }

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const {
 
 const {
   create: post,
+  schema: postSchema,
   validate: isPost
 } = require('./post')
 
@@ -29,7 +30,7 @@ const {
 module.exports = {
   name, image, aboutSchema, isAbout,
   follow, unfollow, block, unblock,
-  post, isPost,
+  post, postSchema, isPost,
   postEdit,
   pub,
   vote

--- a/index.js
+++ b/index.js
@@ -1,127 +1,35 @@
-var mlib = require('ssb-msgs')
-var ssbref = require('ssb-ref')
+const {
+  create: { name, image } 
+} = require('./about')
 
-function link (l) {
-  if (typeof l == 'string') {
-    if (ssbref.isLink(l))
-      return l
-  }
-  if (l && typeof l == 'object') {
-    if (Object.keys(l).length === 1 && l.link && ssbref.isLink(l))
-      return l
-    return mlib.link(l)
-  }
+const {
+  create: { follow, unfollow, block, unblock }
+} = require('./contact')
+
+const { 
+  create: post
+} = require('./post')
+
+
+const {
+  create: postEdit
+} = require('./post-edit')
+
+const { 
+  create: pub
+} = require('./pub')
+
+const { 
+  create: vote
+} = require('./vote')
+
+
+module.exports = {
+  post,
+  name, image,
+  follow, unfollow,
+  block, unblock,
+  pub,
+  vote
 }
 
-function links (l) {
-  if (!l)
-    return
-  if (!Array.isArray(l))
-    l = [l]
-  return l.map(link)
-}
-
-exports.post = function (text, root, branch, mentions, recps, channel) {
-  var content = { type: 'post', text: text }
-  if (root) {
-    root = link(root)
-    if (!root)
-      throw new Error('root is not a valid link')
-    content.root = root
-  }
-  if (branch) {
-    branch = link(branch)
-    if (!branch)
-      throw new Error('branch is not a valid link')
-    content.branch = branch
-  }
-  if (mentions && (!Array.isArray(mentions) || mentions.length)) {
-    mentions = links(mentions)
-    if (!mentions || !mentions.length)
-      throw new Error('mentions are not valid links')
-    content.mentions = mentions
-  }
-  if (recps && (!Array.isArray(recps) || recps.length)) {
-    recps = links(recps)
-    if (!recps || !recps.length)
-      throw new Error('recps are not valid links')
-    content.recps = recps
-  }
-  if (channel) {
-    if (typeof channel !== 'string')
-      throw new Error('channel must be a string')
-    content.channel = channel
-  }
-
-  return content
-}
-
-exports.postEdit = function(text, root, revisionRoot, revisionBranch, mentions) {
-  var content = { type: 'post-edit', text: text }
-  if (root) {
-    root = link(root)
-    if (!root)
-      throw new Error('root is not a valid link')
-    content.root = root
-  }
-  
-  revisionRoot = link(revisionRoot)
-  if (!revisionRoot)
-    throw new Error('revisionRoot is not a valid link')
-  content.revisionRoot = revisionRoot
-
-  revisionBranch = link(revisionBranch)
-  if (!revisionBranch)
-    throw new Error('revisionBranch is not a valid link')
-  content.revisionBranch = revisionBranch
-
-  if (mentions && (!Array.isArray(mentions) || mentions.length)) {
-    mentions = links(mentions)
-    if (!mentions || !mentions.length)
-      throw new Error('mentions are not valid links')
-    content.mentions = mentions
-  }
-  
-  return content  
-}
-
-exports.name = function (userId, name) {
-  return { type: 'about', about: link(userId), name: name }
-}
-
-exports.image = function (userId, imgLink) {
-  return { type: 'about', about: link(userId), image: link(imgLink) }
-}
-
-exports.follow = function (userId) {
-  return { type: 'contact', contact: link(userId), following: true, blocking: false }
-}
-
-exports.unfollow = function (userId) {
-  return { type: 'contact', contact: link(userId), following: false }
-}
-
-exports.block = function (userId) {
-  return { type: 'contact', contact: link(userId), following: false, blocking: true }
-}
-
-exports.unblock = function (userId) {
-  return { type: 'contact', contact: link(userId), blocking: false }
-}
-
-exports.vote = function (id, vote, reason) {
-  var voteLink = mlib.link(id)
-  if (!voteLink)
-    throw new Error('invalid target id')
-  voteLink.value = vote
-  if (reason && typeof reason === 'string')
-    voteLink.reason = reason
-  return { type: 'vote', vote: voteLink }
-}
-
-exports.pub = function (id, host, port) {
-  var publink = mlib.link(id)
-  publink.host = host
-  publink.port = port
-  return { type: 'pub', pub: publink }
-}

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ module.exports = {
   name, image, aboutSchema, isAbout,
   follow, unfollow, block, unblock,
   post, isPost,
+  postEdit,
   pub,
   vote
 }

--- a/index.js
+++ b/index.js
@@ -1,12 +1,14 @@
 const {
-  create: { name, image } 
+  create: { name, image },
+  schema: aboutSchema,
+  validate: isAbout
 } = require('./about')
 
 const {
   create: { follow, unfollow, block, unblock }
 } = require('./contact')
 
-const { 
+const {
   create: post
 } = require('./post')
 
@@ -19,16 +21,14 @@ const {
   create: pub
 } = require('./pub')
 
-const { 
+const {
   create: vote
 } = require('./vote')
 
-
 module.exports = {
+  name, image, aboutSchema, isAbout,
+  follow, unfollow, block, unblock,
   post,
-  name, image,
-  follow, unfollow,
-  block, unblock,
   pub,
   vote
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "validation and publishing methods for common ssb message types",
   "main": "index.js",
   "scripts": {
-    "test": "set -e; for t in test/*.js; do node $t; done",
+    "test": "tape test/*.js | tap-spec",
     "lint": "standard",
     "lint:fix": "standard --fix"
   },
@@ -13,12 +13,14 @@
     "url": "git://github.com/ssbc/ssb-msg-schemas.git"
   },
   "dependencies": {
+    "is-my-json-valid": "^2.16.0",
     "pull-stream": "~2.27.0",
     "ssb-msgs": "^5.0.0",
-    "ssb-ref": "~2.0.0"
+    "ssb-ref": "^2.7.0"
   },
   "devDependencies": {
     "standard": "^10.0.2",
+    "tap-spec": "^4.1.1",
     "tape": "~3.0.0"
   },
   "author": "Paul Frazee <pfrazee@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "validation and publishing methods for common ssb message types",
   "main": "index.js",
   "scripts": {
-    "test": "set -e; for t in test/*.js; do node $t; done"
+    "test": "set -e; for t in test/*.js; do node $t; done",
+    "lint": "standard",
+    "lint:fix": "standard --fix"
   },
   "repository": {
     "type": "git",
@@ -16,6 +18,7 @@
     "ssb-ref": "~2.0.0"
   },
   "devDependencies": {
+    "standard": "^10.0.2",
     "tape": "~3.0.0"
   },
   "author": "Paul Frazee <pfrazee@gmail.com>",

--- a/post-edit.js
+++ b/post-edit.js
@@ -1,0 +1,41 @@
+const { link, links } = require('./util') 
+
+function create (text, root, revisionRoot, revisionBranch, mentions) {
+  var content = { type: 'post-edit', text: text }
+  if (root) {
+    root = link(root)
+    if (!root)
+      throw new Error('root is not a valid link')
+    content.root = root
+  }
+  
+  revisionRoot = link(revisionRoot)
+  if (!revisionRoot)
+    throw new Error('revisionRoot is not a valid link')
+  content.revisionRoot = revisionRoot
+
+  revisionBranch = link(revisionBranch)
+  if (!revisionBranch)
+    throw new Error('revisionBranch is not a valid link')
+  content.revisionBranch = revisionBranch
+
+  if (mentions && (!Array.isArray(mentions) || mentions.length)) {
+    mentions = links(mentions)
+    if (!mentions || !mentions.length)
+      throw new Error('mentions are not valid links')
+    content.mentions = mentions
+  }
+  
+  return content  
+}
+
+const schema = {}
+
+const valitate = () => {}
+
+module.exports = {
+  create,
+  schema,
+  valitate
+}
+

--- a/post.js
+++ b/post.js
@@ -1,4 +1,7 @@
-const { link, links } = require('./util')
+const Validate = require('is-my-json-valid')
+const { msgIdRegex, blobIdRegex } = require('ssb-ref')
+
+const { link, links, stringifyRegex } = require('./util')
 
 function create (text, root, branch, mentions, recps, channel) {
   var content = { type: 'post', text }
@@ -32,14 +35,32 @@ function create (text, root, branch, mentions, recps, channel) {
   return content
 }
 
-function validate () {
+const schema = {
+  $schema: 'https://www.github.com/ssbc/patchcore',
+  type: 'object',
+  definitions: {
+    messageId: {
+      type: 'string',
+      pattern: stringifyRegex(msgIdRegex)
+    }
+  },
+  required: ['type', 'text'],
+  properties: {
+    type: {
+      type: 'string',
+      pattern: '^post$'
+    },
+    text: { type: 'string' },
+    root: { $ref: '#/definitions/messageId' },
+    branch: { $ref: '#/definitions/messageId' },
+  }
 }
 
-const schema = {}
+const validate = Validate(schema, { verbose: true })
 
 module.exports = {
   create,
-  validate,
-  schema
+  schema,
+  validate
 }
 

--- a/post.js
+++ b/post.js
@@ -1,7 +1,7 @@
 const Validate = require('is-my-json-valid')
 const { msgIdRegex, feedIdRegex, blobIdRegex } = require('ssb-ref')
 
-const { link, links, stringifyRegex } = require('./util')
+const { link, links } = require('./util')
 
 function create (text, root, branch, mentions, recps, channel) {
   var content = { type: 'post', text }
@@ -47,7 +47,12 @@ const schema = {
     text: { type: 'string' },
     channel: { type: 'string', },
     root: { $ref: '#/definitions/messageId' },
-    branch: { $ref: '#/definitions/messageId' },
+    branch: {
+      oneOf: [
+        { $ref: '#/definitions/messageId' },
+        { type: 'array', items: { $ref: '#/definitions/messageId' } }
+      ]
+    },
     mentions: {
       oneOf: [
         { type: 'null' },
@@ -81,15 +86,15 @@ const schema = {
   definitions: {
     messageId: {
       type: 'string',
-      pattern: stringifyRegex(msgIdRegex)
+      pattern: msgIdRegex
     },
     feedId: {
       type: 'string',
-      pattern: stringifyRegex(feedIdRegex)
+      pattern: feedIdRegex
     },
     blobId: {
       type: 'string',
-      pattern: stringifyRegex(blobIdRegex)
+      pattern: blobIdRegex
     },
     mentions: {
       message: {

--- a/post.js
+++ b/post.js
@@ -41,7 +41,7 @@ function create (text, root, branch, mentions, recps, channel) {
 }
 
 const schema = {
-  $schema: 'https://www.github.com/ssbc/patchcore',
+  $schema: 'http://json-schema.org/schema#',
   type: 'object',
   required: ['type', 'text'],
   properties: {

--- a/post.js
+++ b/post.js
@@ -1,4 +1,4 @@
-const { link, links } = require('./util/link') 
+const { link, links } = require('./util')
 
 function create (text, root, branch, mentions, recps, channel) {
   var content = { type: 'post', text }

--- a/post.js
+++ b/post.js
@@ -1,0 +1,45 @@
+const { link, links } = require('./util/link') 
+
+function create (text, root, branch, mentions, recps, channel) {
+  var content = { type: 'post', text }
+  if (root) {
+    root = link(root)
+    if (!root) { throw new Error('root is not a valid link') }
+    content.root = root
+  }
+  if (branch) {
+    branch = link(branch)
+    if (!root) { throw new Error('must provide root is if describing a branch') }
+    if (!branch) { throw new Error('branch is not a valid link') }
+    content.branch = branch
+  }
+  if (mentions && (!Array.isArray(mentions) || mentions.length)) {
+    mentions = links(mentions)
+    if (!mentions || !mentions.length) { throw new Error('mentions are not valid links') }
+    content.mentions = mentions
+  }
+  if (recps && (!Array.isArray(recps) || recps.length)) {
+    recps = links(recps)
+    if (!recps || !recps.length) { throw new Error('recps are not valid links') }
+    content.recps = recps
+  }
+  if (channel) {
+    if (typeof channel !== 'string')
+      throw new Error('channel must be a string')
+    content.channel = channel
+  }
+
+  return content
+}
+
+function validate () {
+}
+
+const schema = {}
+
+module.exports = {
+  create,
+  validate,
+  schema
+}
+

--- a/pub.js
+++ b/pub.js
@@ -1,0 +1,19 @@
+const mlib = require('ssb-msgs')
+
+function create (id, host, port) {
+  var publink = mlib.link(id)
+  publink.host = host
+  publink.port = port
+  return { type: 'pub', pub: publink }
+}
+
+const schema = {}
+
+function validate () {
+}
+
+module.exports = {
+  create,
+  schema,
+  validate
+}

--- a/test/about.js
+++ b/test/about.js
@@ -1,0 +1,21 @@
+const test = require('tape')
+
+const { name: Name, image: Image } = require('../')
+const { postId, msgId, msgId2, feedId, blobId } = require('./mockIds')
+
+test('About create', t => {
+  t.deepEqual(
+    Name(feedId, 'donna'),
+    { type: 'about', about: feedId, name: 'donna' },
+    'Name creates a message which assigns a feed name'
+  )
+
+  t.deepEqual(
+    Image(feedId, { link: blobId, size: 123 }),
+    { type: 'about', about: feedId, image: { link: blobId, size: 123 } },
+    'Image creates a message which assigns a feed image'
+  )
+
+  t.end()
+})
+

--- a/test/about.js
+++ b/test/about.js
@@ -34,6 +34,13 @@ test('About validate', t => {
     'passes well formed image-type about messages'
   )
 
+  t.true(
+    isAbout({
+      type: 'about', about: feedId, image: blobId, description: 'mememe', other: 'woop'
+    }),
+    'passes well formed image-type about messages (with string-image)'
+  )
+
   t.false(
     isAbout({
       type: 'aboot', about: feedId
@@ -61,6 +68,12 @@ test('About validate', t => {
     }),
     'fails dud image (must have blobIds)'
   )
+  t.false(
+    isAbout({
+      type: 'about', about: feedId, image: 'badBlobId'
+    }),
+    'fails dud image (must have blobIds - string version)'
+  )
 
   t.false(
     isAbout({
@@ -69,12 +82,13 @@ test('About validate', t => {
     'fails dud image (must have size)'
   )
 
-  t.false(
-    isAbout({
-      type: 'about', about: feedId
-    }),
-    'fails message which has neither name nor image nor description'
-  )
+  // TODO : extract for about profile in patchbay
+  // t.false(
+  //   isAbout({
+  //     type: 'about', about: feedId
+  //   }),
+  //   'fails message which has neither name nor image nor description'
+  // )
 
   t.end()
 })

--- a/test/about.js
+++ b/test/about.js
@@ -1,7 +1,7 @@
 const test = require('tape')
 
-const { name: Name, image: Image } = require('../')
-const { postId, msgId, msgId2, feedId, blobId } = require('./mockIds')
+const { name: Name, image: Image, isAbout } = require('../')
+const { feedId, blobId } = require('./mockIds')
 
 test('About create', t => {
   t.deepEqual(
@@ -14,6 +14,66 @@ test('About create', t => {
     Image(feedId, { link: blobId, size: 123 }),
     { type: 'about', about: feedId, image: { link: blobId, size: 123 } },
     'Image creates a message which assigns a feed image'
+  )
+
+  t.end()
+})
+
+test('About validate', t => {
+  t.true(
+    isAbout({
+      type: 'about', about: feedId, name: 'donna'
+    }),
+    'passes well formed name-type about messages'
+  )
+
+  t.true(
+    isAbout({
+      type: 'about', about: feedId, image: { link: blobId, size: 123 }
+    }),
+    'passes well formed image-type about messages'
+  )
+
+  t.false(
+    isAbout({
+      type: 'aboot', about: feedId
+    }),
+    'fails non-about messages'
+  )
+
+  t.false(
+    isAbout({
+      type: 'about', about: 'dudFeedId', name: 'donna'
+    }),
+    'fails dud about ids'
+  )
+
+  t.false(
+    isAbout({
+      type: 'about', about: feedId, name: 22
+    }),
+    'fails dud name'
+  )
+
+  t.false(
+    isAbout({
+      type: 'about', about: feedId, image: { link: 'badBlobId', size: 123 }
+    }),
+    'fails dud image (must have blobIds)'
+  )
+
+  t.false(
+    isAbout({
+      type: 'about', about: feedId, image: { link: blobId, size: 'dave' }
+    }),
+    'fails dud image (must have size)'
+  )
+
+  t.false(
+    isAbout({
+      type: 'about', about: feedId
+    }),
+    'fails message which has neither name nor image'
   )
 
   t.end()

--- a/test/about.js
+++ b/test/about.js
@@ -29,7 +29,7 @@ test('About validate', t => {
 
   t.true(
     isAbout({
-      type: 'about', about: feedId, image: { link: blobId, size: 123 }
+      type: 'about', about: feedId, image: { link: blobId, size: 123 }, description: 'mememe', other: 'woop'
     }),
     'passes well formed image-type about messages'
   )
@@ -73,7 +73,7 @@ test('About validate', t => {
     isAbout({
       type: 'about', about: feedId
     }),
-    'fails message which has neither name nor image'
+    'fails message which has neither name nor image nor description'
   )
 
   t.end()

--- a/test/contact.js
+++ b/test/contact.js
@@ -1,7 +1,7 @@
 const test = require('tape')
 
 const { follow, unfollow, block, unblock } = require('../')
-const { postId, msgId, msgId2, feedId, blobId } = require('./mockIds')
+const { feedId } = require('./mockIds')
 
 test('Contact creators', t => {
   t.deepEqual(

--- a/test/contact.js
+++ b/test/contact.js
@@ -1,0 +1,28 @@
+const test = require('tape')
+
+const { follow, unfollow, block, unblock } = require('../')
+const { postId, msgId, msgId2, feedId, blobId } = require('./mockIds')
+
+test('Contact creators', t => {
+  t.deepEqual(
+    follow(feedId),
+    { type: 'contact', contact: feedId, following: true, blocking: false },
+    'follow'
+  )
+  t.deepEqual(
+    unfollow(feedId),
+    { type: 'contact', contact: feedId, following: false },
+    'unfollow'
+  )
+  t.deepEqual(
+    block(feedId),
+    { type: 'contact', contact: feedId, following: false, blocking: true },
+    'block'
+  )
+  t.deepEqual(
+    unblock(feedId),
+    { type: 'contact', contact: feedId, blocking: false },
+    'unblock'
+  )
+  t.end()
+})

--- a/test/index.js
+++ b/test/index.js
@@ -27,15 +27,6 @@ tape('schemas', function (t) {
     schemas.post('text', null, null, null, null, 'stuff'),
     { type: 'post', text: 'text', channel: 'stuff' }
   )
-  t.throws(function() { schemas.postEdit('revised text') })
-  t.deepEqual(
-    schemas.postEdit('revised text', msgid, msgid, msgid, [feedid]),
-    { type: 'post-edit', text: 'revised text', root: msgid, revisionRoot: msgid, revisionBranch: msgid, mentions: [feedid]}
-  )
-  t.deepEqual(
-    schemas.postEdit('revised text', msgid, msgid2, msgid2, null),
-    { type: 'post-edit', text: 'revised text', root: msgid, revisionRoot: msgid2, revisionBranch: msgid2}
-  )
   t.deepEqual(
     schemas.name(feedid, 'name'),
     { type: 'about', about: feedid, name: 'name' }

--- a/test/mockIds.js
+++ b/test/mockIds.js
@@ -1,0 +1,6 @@
+module.exports = {
+  feedId: '@5BmAwnJXrDVYje5FJX6Cg1eolZiWLZsThd5p/4ZJ6VY=.ed25519',
+  msgId: '%RYnp9p24dlAPYGhrsFYdGGHIAYM2uM5pr1//RocCF/U=.sha256',
+  msgId2: '%SYnp9p24dlAPYGhrsFYdGGHIAYM2uM5pr1//RocCF/U=.sha256',
+  blobId: '&RYnp9p24dlAPYGhrsFYdGGHIAYM2uM5pr1//RocCF/U=.sha256'
+}

--- a/test/post-edit.js
+++ b/test/post-edit.js
@@ -13,4 +13,5 @@ test('Post-edit create', t => {
     postEdit('revised text', msgId, msgId2, msgId2, null),
     { type: 'post-edit', text: 'revised text', root: msgId, revisionRoot: msgId2, revisionBranch: msgId2}
   )
+  t.end()
 })

--- a/test/post-edit.js
+++ b/test/post-edit.js
@@ -1,0 +1,16 @@
+const test = require('tape')
+
+const { postEdit } = require('../')
+const { msgId, msgId2, feedId } = require('./mockIds')
+
+test('Post-edit create', t => {
+  t.throws(() => postEdit('revised text') )
+  t.deepEqual(
+    postEdit('revised text', msgId, msgId, msgId, [feedId]),
+    { type: 'post-edit', text: 'revised text', root: msgId, revisionRoot: msgId, revisionBranch: msgId, mentions: [feedId]}
+  )
+  t.deepEqual(
+    postEdit('revised text', msgId, msgId2, msgId2, null),
+    { type: 'post-edit', text: 'revised text', root: msgId, revisionRoot: msgId2, revisionBranch: msgId2}
+  )
+})

--- a/test/post.js
+++ b/test/post.js
@@ -1,6 +1,6 @@
 const test = require('tape')
 
-const { post: Post } = require('../')
+const { post: Post, isPost } = require('../')
 const { msgId, msgId2, feedId, blobId } = require('./mockIds')
 
 test('Post create', t => {
@@ -27,3 +27,61 @@ test('Post create', t => {
 
   t.end()
 })
+
+test('Post validate', t => {
+  t.true(
+    isPost({
+      type: 'post',
+      text: 'here is a some text'
+    }),
+    'passes simple post message'
+  )
+
+  t.false(
+    isPost({
+      type: 'posts',
+      text: 'here is a some text'
+    }),
+    'fails non-post messages'
+  )
+
+  t.false(
+    isPost({
+      type: 'posts'
+    }),
+    'fails post without text'
+  )
+
+  t.true(
+    isPost({
+      type: 'post',
+      text: 'here is a some text',
+      root: msgId,
+      branch: msgId2
+    }),
+    'passes simple reply-post message'
+  )
+
+  t.false(
+    isPost({
+      type: 'post',
+      text: 'here is a some text',
+      root: 'not a root id',
+      branch: msgId2
+    }),
+    'fails reply test if root is not a feed id'
+  )
+  t.false(
+    isPost({
+      type: 'post',
+      text: 'here is a some text',
+      root: msgId,
+      branch: 'not a branch id'
+    }),
+    'fails reply test if branch is not a feed id'
+  )
+
+
+  t.end()
+})
+

--- a/test/post.js
+++ b/test/post.js
@@ -1,7 +1,7 @@
 const test = require('tape')
 
 const { post: Post } = require('../')
-const { postId, msgId, msgId2, feedId, blobId } = require('./mockIds')
+const { msgId, msgId2, feedId, blobId } = require('./mockIds')
 
 test('Post create', t => {
   t.deepEqual(

--- a/test/post.js
+++ b/test/post.js
@@ -70,6 +70,15 @@ test('Post validate', t => {
     }),
     'passes simple reply-post message'
   )
+  t.true(
+    isPost({
+      type: 'post',
+      text: 'here is a some text',
+      root: msgId,
+      branch: [ msgId2 ]  // could be one or more ids
+    }),
+    'passes simple reply-post message'
+  )
   t.false(
     isPost({
       type: 'post',

--- a/test/post.js
+++ b/test/post.js
@@ -1,0 +1,29 @@
+const test = require('tape')
+
+const { post: Post } = require('../')
+const { postId, msgId, msgId2, feedId, blobId } = require('./mockIds')
+
+test('Post create', t => {
+  t.deepEqual(
+    Post('dog'),
+    { type: 'post', text: 'dog' }
+  )
+  t.deepEqual(
+    Post('dog', msgId, msgId2, null, [feedId]),
+    { type: 'post', text: 'dog', root: msgId, branch: msgId2, recps: [feedId] }
+  )
+  t.deepEqual(
+    Post('dog', null, null, [feedId, msgId, blobId]),
+    { type: 'post', text: 'dog', mentions: [feedId, msgId, blobId] }
+  )
+  t.deepEqual(
+    Post('dog', msgId, msgId2, [feedId, msgId, blobId], [feedId]),
+    { type: 'post', text: 'dog', root: msgId, branch: msgId2, mentions: [feedId, msgId, blobId], recps: [feedId] }
+  )
+
+  t.throws(() => Post('dog', null, msgId2), 'if there is a branch, there should also be a root')
+
+  // TODO : test possible malformed Ids coming in
+
+  t.end()
+})

--- a/test/post.js
+++ b/test/post.js
@@ -3,6 +3,10 @@ const test = require('tape')
 const { post: Post, isPost } = require('../')
 const { msgId, msgId2, feedId, blobId } = require('./mockIds')
 
+// NOTE : to check validation errors, you can do this:
+// isPost( testMsg )
+// console.log('show errors on last validation', isPost.errors)
+
 test('Post create', t => {
   t.deepEqual(
     Post('dog'),
@@ -29,6 +33,9 @@ test('Post create', t => {
 })
 
 test('Post validate', t => {
+
+  // SIMPLE POST
+
   t.true(
     isPost({
       type: 'post',
@@ -52,6 +59,8 @@ test('Post validate', t => {
     'fails post without text'
   )
 
+  // REPLIES
+
   t.true(
     isPost({
       type: 'post',
@@ -61,7 +70,6 @@ test('Post validate', t => {
     }),
     'passes simple reply-post message'
   )
-
   t.false(
     isPost({
       type: 'post',
@@ -81,6 +89,149 @@ test('Post validate', t => {
     'fails reply test if branch is not a feed id'
   )
 
+  // CHANNELS
+
+  t.true(
+    isPost({
+      type: 'post',
+      text: 'here is a some text',
+      channel: 'new-zealand',
+    }),
+    'passes post with channel'
+  )
+  t.false(
+    isPost({
+      type: 'post',
+      text: 'here is a some text',
+      channel: 23,
+    }),
+    'fails post with non-string channel'
+  )
+
+  // MENTIONS
+
+  t.true(
+    isPost({
+      type: 'post',
+      text: 'here is a some text',
+      mentions: [
+        {
+          link: feedId,
+          name: 'Piet'
+        },
+        {
+          link: blobId,
+          name: 'Tararuras.jpg'
+        },
+        {
+          link: msgId 
+        }
+      ]
+    }),
+    'passes post with combination of feed + blob + message mentions'
+  )
+  t.true(
+    isPost({
+      type: 'post',
+      text: 'here is a some text',
+      mentions: null
+    }),
+    'passes post with null mentions'
+  )
+  t.true(
+    isPost({
+      type: 'post',
+      text: 'here is a some text',
+      mentions: []
+    }),
+    'passes post with empty mentions'
+  )
+
+  t.false(
+    isPost({
+      type: 'post',
+      text: 'here is a some text',
+      mentions: [
+        {
+          link: 'not a link',
+          name: 'Piet'
+        },
+      ]
+    }),
+    'fails a post with a dud mention link'
+  )
+  t.false(
+    isPost({
+      type: 'post',
+      text: 'here is a some text',
+      mentions: [
+        msgId
+      ]
+    }),
+    'fails a post with badly formed mentions'
+  )
+
+  // RECPS
+
+  t.true(
+    isPost({
+      type: 'post',
+      text: 'here is a some text',
+      recps: [
+        feedId,
+        {
+          link: feedId,
+          name: 'Piet'
+        }
+      ]
+    }),
+    'passes post with combination of recipient mentions'
+  )
+  t.true(
+    isPost({
+      type: 'post',
+      text: 'here is a some text',
+      recps: null
+    }),
+    'passes post with null recps'
+  )
+  t.true(
+    isPost({
+      type: 'post',
+      text: 'here is a some text',
+      recps: []
+    }),
+    'passes post with empty recps'
+  )
+
+  t.false(
+    isPost({
+      type: 'post',
+      text: 'here is a some text',
+      recps: [
+        'not an id',
+        {
+          link: feedId,
+          name: 'Piet'
+        }
+      ]
+    }),
+    'fails a post with a broken string recps'
+  )
+  t.false(
+    isPost({
+      type: 'post',
+      text: 'here is a some text',
+      recps: [
+        feedId,
+        {
+          link: 'not an Id',
+          name: 'Piet'
+        }
+      ]
+    }),
+    'fails a post with a broken link recps'
+  )
 
   t.end()
 })

--- a/test/pub.js
+++ b/test/pub.js
@@ -1,7 +1,7 @@
 const test = require('tape')
 
 const { pub: Pub } = require('../')
-const { postId, msgId, msgId2, feedId, blobId } = require('./mockIds')
+const { feedId } = require('./mockIds')
 
 test('Pub create', t => {
   t.deepEqual(

--- a/test/pub.js
+++ b/test/pub.js
@@ -1,0 +1,12 @@
+const test = require('tape')
+
+const { pub: Pub } = require('../')
+const { postId, msgId, msgId2, feedId, blobId } = require('./mockIds')
+
+test('Pub create', t => {
+  t.deepEqual(
+    Pub(feedId, 'host.co', 123),
+    { type: 'pub', pub: { link: feedId, host: 'host.co', port: 123 } }
+  )
+  t.end()
+})

--- a/test/vote.js
+++ b/test/vote.js
@@ -1,0 +1,16 @@
+const test = require('tape')
+
+const { vote: Vote } = require('../')
+const { postId, msgId, msgId2, feedId, blobId } = require('./mockIds')
+
+test('Vote create', function (t) {
+  t.deepEqual(
+    Vote(msgId, 1),
+    { type: 'vote', vote: { link: msgId, value: 1 } }
+  )
+  t.deepEqual(
+    Vote(msgId, -1, 'reason'),
+    { type: 'vote', vote: { link: msgId, value: -1, reason: 'reason' } }
+  )
+  t.end()
+})

--- a/test/vote.js
+++ b/test/vote.js
@@ -1,7 +1,7 @@
 const test = require('tape')
 
 const { vote: Vote } = require('../')
-const { postId, msgId, msgId2, feedId, blobId } = require('./mockIds')
+const { msgId } = require('./mockIds')
 
 test('Vote create', function (t) {
   t.deepEqual(
@@ -14,3 +14,4 @@ test('Vote create', function (t) {
   )
   t.end()
 })
+

--- a/util/index.js
+++ b/util/index.js
@@ -17,6 +17,7 @@ function links (l) {
   return l.map(link)
 }
 
+// this may not be needed
 function stringifyRegex (regex) {
   return regex.toString()
     .replace(/^\//, '')

--- a/util/index.js
+++ b/util/index.js
@@ -17,8 +17,15 @@ function links (l) {
   return l.map(link)
 }
 
+function stringifyRegex (regex) {
+  return regex.toString()
+    .replace(/^\//, '')
+    .replace(/\/$/, '')
+}
+
 module.exports = {
   link,
-  links
+  links,
+  stringifyRegex
 }
 

--- a/util/link.js
+++ b/util/link.js
@@ -1,0 +1,24 @@
+const mlib = require('ssb-msgs')
+const { isLink } = require('ssb-ref')
+
+function link (l) {
+  if (typeof l === 'string') {
+    if (isLink(l)) { return l }
+  }
+  if (l && typeof l === 'object') {
+    if (Object.keys(l).length === 1 && l.link && isLink(l)) { return l }
+    return mlib.link(l)
+  }
+}
+
+function links (l) {
+  if (!l) return
+  if (!Array.isArray(l)) l = [l]
+  return l.map(link)
+}
+
+module.exports = {
+  link,
+  links
+}
+

--- a/vote.js
+++ b/vote.js
@@ -1,0 +1,20 @@
+const mlib = require('ssb-msgs')
+
+function create (id, vote, reason) {
+  var voteLink = mlib.link(id)
+  if (!voteLink) { throw new Error('invalid target id') }
+  voteLink.value = vote
+  if (reason && typeof reason === 'string') { voteLink.reason = reason }
+  return { type: 'vote', vote: voteLink }
+}
+
+const schema = {}
+
+function validate () {
+}
+
+module.exports = {
+  create,
+  schema,
+  validate
+}


### PR DESCRIPTION
This adds the export of `isPost` and `isAbout` validators.
The motivation is to provide a clear and easy way for parts of patch* to check whether a message
- has some minimum expected anatomy (for a particular type)
- does not harbour malformed data in a nice layout.

I've only written `isPost` and `isAbout` sofar, because they are the most common ones for people to clutz-up posting, they're the most complicated, and I want to discuss the pattern I've created.

I've used JSON-Schema and `is-my-json-valid`. I'm also exporting the schema I've made, so that others can leverage them if that's useful. 

This leaves the current parts of the API unchanged.
I've split the index.js into the constituent message types .
