### PR TITLE
Allow multiple values for branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Functions to create common SSB messages.
 
 ```js
-{ type: 'post', text: String, channel: String, root: MsgLink, branch: MsgLink, recps: FeedLinks, mentions: Links }
+{ type: 'post', text: String, channel: String, root: MsgLink, branch: MsgLink|MsgLinks, recps: FeedLinks, mentions: Links }
 { type: 'post-edit', text: String, root: MsgLink, revisionRoot: MsgLink, revisionBranch: MsgLink, mentions: Links }
 { type: 'about', about: Link, name: String, image: BlobLink }
 { type: 'contact', contact: FeedLink, following: Bool, blocking: Bool }
@@ -44,13 +44,13 @@ schemas.pub(id, host, port)
 ### type: post
 
 ```js
-{ type: 'post', text: String, channel: String, root: MsgLink, branch: MsgLink, recps: FeedLinks, mentions: Links }
+{ type: 'post', text: String, channel: String, root: MsgLink, branch: MsgLink|MsgLinks, recps: FeedLinks, mentions: Links }
 ```
 
  - `channel` is optionally used to filter posts into groups, similar to subreddits or chat channels.
  - `root` and `branch` are for replies.
    - `root` should point to the topmost message in the thread.
-   - `branch` should point to the message in the thread which is being replied to.
+   - `branch` should point to the message or set of messages in the thread which is being replied to.
    - In the first reply of a thread, `root === branch`, and both should be included.
    - `root` and `branch` should only point to `type: post` messages. If the post is about another message-type, use `mentions`.
  - `mentions` is a generic reference to other feeds, entities, or blobs.

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ exports.post = function (text, root, branch, mentions, recps, channel) {
     content.root = root
   }
   if (branch) {
-    branch = link(branch)
+    branch = Array.isArray(branch) ? branch.map(link) : link(branch)
     if (!branch)
       throw new Error('branch is not a valid link')
     content.branch = branch

--- a/test/index.js
+++ b/test/index.js
@@ -24,6 +24,10 @@ tape('schemas', function (t) {
     { type: 'post', text: 'text', root: msgid, branch: msgid2, mentions: [feedid, msgid, blobid], recps: [feedid] }
   )
   t.deepEqual(
+    schemas.post('text', msgid, [msgid, msgid2]),
+    { type: 'post', text: 'text', root: msgid, branch: [msgid, msgid2] }
+  )
+  t.deepEqual(
     schemas.post('text', null, null, null, null, 'stuff'),
     { type: 'post', text: 'text', channel: 'stuff' }
   )


### PR DESCRIPTION
Update the schema to include allowing posts to reply to multiple messages, by letting the branch property be an array or a scalar. Reasons for using the array are described in %ftFD7xu4TksPr9U3SHw5VWVNFNtGMzomdpPJnLH2oLY=.sha256 and %c512tK3wDVlL+7x365Tn0KJ5C7JU1Y6eCXKuPdtVvh0=.sha256. This is as implemented in patchbay < 7, patchfoo, ssbc/patchcore/pull/18 and in the validators in #16 