### PR TITLE
wip: add channel mentions

### DIFF
--- a/post.js
+++ b/post.js
@@ -3,6 +3,8 @@ const { msgIdRegex, feedIdRegex, blobIdRegex } = require('ssb-ref')
 
 const { link, links } = require('./util')
 
+const channelIdRegex = /^#.*$/
+
 function create (text, root, branch, mentions, recps, channel) {
   var content = { type: 'post', text }
   if (root) {
@@ -67,7 +69,8 @@ const schema = {
             oneOf: [
               { $ref: '#/definitions/mentions/message' },
               { $ref: '#/definitions/mentions/feed' },
-              { $ref: '#/definitions/mentions/blob' }
+              { $ref: '#/definitions/mentions/blob' },
+              { $ref: '#/definitions/mentions/channel' }
             ]
           }
         }
@@ -101,6 +104,10 @@ const schema = {
       type: 'string',
       pattern: blobIdRegex
     },
+    channelId: {
+      type: 'string',
+      pattern: channelIdRegex
+    },
     mentions: {
       message: {
         type: 'object',
@@ -124,8 +131,14 @@ const schema = {
           link: { $ref: '#/definitions/blobId'},
           name: { type: 'string' }
         }
+      },
+      channel: {
+        type: 'object',
+        required: ['link'],
+        properties: {
+          link: { $ref: '#/definitions/channelId'}
+        }
       }
-
     }
   },
 }

--- a/test/mockIds.js
+++ b/test/mockIds.js
@@ -2,5 +2,6 @@ module.exports = {
   feedId: '@5BmAwnJXrDVYje5FJX6Cg1eolZiWLZsThd5p/4ZJ6VY=.ed25519',
   msgId: '%RYnp9p24dlAPYGhrsFYdGGHIAYM2uM5pr1//RocCF/U=.sha256',
   msgId2: '%SYnp9p24dlAPYGhrsFYdGGHIAYM2uM5pr1//RocCF/U=.sha256',
-  blobId: '&RYnp9p24dlAPYGhrsFYdGGHIAYM2uM5pr1//RocCF/U=.sha256'
+  blobId: '&RYnp9p24dlAPYGhrsFYdGGHIAYM2uM5pr1//RocCF/U=.sha256',
+  channelId: '#cooking-channel'
 }

--- a/test/post.js
+++ b/test/post.js
@@ -1,7 +1,7 @@
 const test = require('tape')
 
 const { post: Post, isPost } = require('../')
-const { msgId, msgId2, feedId, blobId } = require('./mockIds')
+const { msgId, msgId2, feedId, blobId, channelId } = require('./mockIds')
 
 // NOTE : to check validation errors, you can do this:
 // isPost( testMsg )
@@ -17,8 +17,8 @@ test('Post create', t => {
     { type: 'post', text: 'dog', root: msgId, branch: msgId2, recps: [feedId] }
   )
   t.deepEqual(
-    Post('dog', null, null, [feedId, msgId, blobId]),
-    { type: 'post', text: 'dog', mentions: [feedId, msgId, blobId] }
+    Post('dog', null, null, [feedId, msgId, blobId, channelId]),
+    { type: 'post', text: 'dog', mentions: [feedId, msgId, blobId, channelId] }
   )
   t.deepEqual(
     Post('dog', msgId, msgId2, [feedId, msgId, blobId], [feedId]),
@@ -134,6 +134,9 @@ test('Post validate', t => {
         },
         {
           link: msgId 
+        },
+        {
+          link: channelId
         }
       ]
     }),


### PR DESCRIPTION
this is a _work in progress_ pull request to add channel mentions to the post message schema.

an example message: [%mlv0+m3nYX8YORUXougdbZ8EMOL1h4KXqtScRd+Vo24=.sha256](https://viewer.scuttlebot.io/%25mlv0%2Bm3nYX8YORUXougdbZ8EMOL1h4KXqtScRd%2BVo24%3D.sha256)

```js
{
  // ...
  "content": {
    // ...
    "mentions": [
      // ...
      {
        "link": "#somebodyshould"
      }
    ]
  },
  // ...
}
```

i actually thought that Patchwork was doing this because channels are a supported sigil in [`ssb-markdown`](https://github.com/ssbc/ssb-markdown/blob/master/index.js#L13), but it seems only Patchfoo supports channel mentions.

if we want this, we'll need to change `ssb-msgs.isLink` to return true for a channel. but then i'm reminded of [%2GUlOLRVd/WwCg3tbWHQf/sTtC2O66cYUyTLxNxstgU=.sha256](https://viewer.scuttlebot.io/%252GUlOLRVd%2FWwCg3tbWHQf%2FsTtC2O66cYUyTLxNxstgU%3D.sha256), maybe we should use this as an opportunity to _do channels right this time_.

what do y'all think?